### PR TITLE
Fixed sample order of annotations

### DIFF
--- a/pyoncoprint/__init__.py
+++ b/pyoncoprint/__init__.py
@@ -39,9 +39,9 @@ class OncoPrint:
             mat = recurrence_matrix
         
         if genes is None:
-            genes = np.array(["Gene %d"%i for i in range(1, arr.shape[0] + 1)])
+            genes = np.array(["Gene %d"%i for i in range(1, recurrence_matrix.shape[0] + 1)])
         if samples is None:
-            samples = np.array(["Sample %d"%i for i in range(1, arr.shape[1] + 1)])
+            samples = np.array(["Sample %d"%i for i in range(1, recurrence_matrix.shape[1] + 1)])
         
         _, uniq_idx = np.unique(genes, return_index=True)
         if len(uniq_idx) != len(genes):

--- a/pyoncoprint/__init__.py
+++ b/pyoncoprint/__init__.py
@@ -82,15 +82,15 @@ class OncoPrint:
         
     def _sort_samples_default(self, mutation_types):
         mutation_to_weight = {mut: i for i, mut in enumerate(mutation_types[::-1], start=1)}
-        weighted_filpped_cntmat = np.zeros_like(self.sorted_mat, dtype=int)
+        weighted_flipped_cntmat = np.zeros_like(self.sorted_mat, dtype=int)
         for i in range(self.sorted_mat.shape[0]):
             for j in range(self.sorted_mat.shape[1]):
                 if self._is_valid_string(self.sorted_mat[i,j]):
                     for mut in np.unique(self.sorted_mat[i,j].split(self.seperator)):
-                        weighted_filpped_cntmat[self.sorted_mat.shape[0] - i - 1, j] += mutation_to_weight.get(mut, 0)
-        sorted_indices = np.lexsort(weighted_filpped_cntmat)[::-1]
-        self.sorted_samples = self.samples[sorted_indices]
-        self.sorted_mat = self.sorted_mat[:, sorted_indices]
+                        weighted_flipped_cntmat[self.sorted_mat.shape[0] - i - 1, j] += mutation_to_weight.get(mut, 0)
+        self.sorted_sample_indices = np.lexsort(weighted_flipped_cntmat)[::-1]
+        self.sorted_samples = self.samples[self.sorted_sample_indices]
+        self.sorted_mat = self.sorted_mat[:, self.sorted_sample_indices]
         
     def oncoprint(self, markers, annotations={},
                   title="",
@@ -156,7 +156,7 @@ class OncoPrint:
             ax_annot_yticks = []
             ax_annot_patches = []
             for i, (annot_type, annot_dic) in enumerate(sorted_annotations):
-                annots = annot_dic['annotations']
+                annots = annot_dic['annotations'][self.sorted_sample_indices]
                 annot_colors = annot_dic['colors']
                 ax_annot_yticks.append(annot_type)
                 for j, annot in enumerate(annots):

--- a/setup.py
+++ b/setup.py
@@ -6,7 +6,7 @@ with io.open("README.rst", "r", encoding="utf-8") as fh:
 
 setuptools.setup(
     name="pyoncoprint",
-    version="0.3.0",
+    version="0.3.1",
     author="Jeongbin Park",
     author_email="jeongbin.park@charite.de",
     description="PyOncoPrint",


### PR DESCRIPTION
Bug fix: if samples are sorted, then the annotations need to be sorted in the same way, otherwise the sample columns in the mutation matrix do not match the annotations. This patch provides a fix for this bug.