### PR TITLE
Fix mutation legend and annotations for unsorted samples

### DIFF
--- a/pyoncoprint/__init__.py
+++ b/pyoncoprint/__init__.py
@@ -106,6 +106,7 @@ class OncoPrint:
         self.sorted_mat = self.mat
         self.sorted_genes = self.genes
         self.sorted_samples = self.samples
+        self.sorted_sample_indices = list(range(len(self.samples)))
         if gene_sort_method != 'unsorted':
             if gene_sort_method == 'default':
                 self._sort_genes_default()

--- a/pyoncoprint/__init__.py
+++ b/pyoncoprint/__init__.py
@@ -322,7 +322,11 @@ class OncoPrint:
                 if is_mut:
                     if label in legend_mut_to_patch:
                         p, w, h, pc_kwargs = legend_mut_to_patch[label]
-                        p.set_transform(p.get_transform() + Affine2D().scale(w, -h).translate(cur_x, cur_y + 0.5 + h * 0.5))
+                        #p.set_transform(p.get_transform() + Affine2D().scale(w, -h).translate(cur_x, cur_y + 0.5 + h * 0.5))
+                        p.set_transform(
+                            p.get_transform()
+                            + Affine2D().scale(w, -h)
+                            .translate(*background_lengths * 0.5 + (cur_x - 0.5 * w, cur_y + 0.5 * h)))
                         legend_pcs.append(PatchCollection([p], **pc_kwargs))
                     elif label in legend_mut_to_scatter:
                         scatter_kwargs = legend_mut_to_scatter[label]

--- a/setup.py
+++ b/setup.py
@@ -6,7 +6,7 @@ with io.open("README.rst", "r", encoding="utf-8") as fh:
 
 setuptools.setup(
     name="pyoncoprint",
-    version="0.3.10",
+    version="0.3.14",
     author="Jeongbin Park",
     author_email="jeongbin.park@charite.de",
     description="PyOncoPrint",

--- a/setup.py
+++ b/setup.py
@@ -6,7 +6,7 @@ with io.open("README.rst", "r", encoding="utf-8") as fh:
 
 setuptools.setup(
     name="pyoncoprint",
-    version="0.3.1",
+    version="0.3.10",
     author="Jeongbin Park",
     author_email="jeongbin.park@charite.de",
     description="PyOncoPrint",


### PR DESCRIPTION
Recently I provided a bug fix for wrongly assigned annotations if samples are resorted. I forgot to properly handle the situation when samples are unsorted. This is now fixed.
Furthermore, the legend for Genomic Alterations was not correctly displayed for patches with width or height other than 1. For example, a rectangle of width=0.5 and height=0.5 was not centered in the background rectangle. This is now also fixed.
Please increase the version number, because otherwise pip won't install the newer version unless a "force" argument is added to force a reinstallation.